### PR TITLE
feat: review password support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@
     if (url.pathname.startsWith("/.snapshots/") && !url.pathname.endsWith(".manifest.json")) {
       return createSnapshotRedirect(url.pathname);
     }
-    const hostname = (url.hostname.endsWith(".hlx.reviews") || url.hostname.endsWith(".aem.reviews")) ? url.hostname : "default--main--aem-boilerplate--adobe.aem.reviews";
+    const hostname = (url.hostname.endsWith(".hlx.reviews") || url.hostname.endsWith(".aem.reviews")) ? url.hostname : (url.searchParams.get("hostname") || "default--main--aem-boilerplate--adobe.aem.reviews");
     const origin = hostname.split(".")[0];
     const [reviewId, ref, repo, owner] = origin.split("--");
     const aem = 'aem';

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ import { parse } from 'cookie';
         console.log(cookies.reviewPassword, reviewPasswordHash);
   
         if (cookies.reviewPassword !== reviewPasswordHash) {
-          return new Response('<html><head><title>Unauthorized</title><script src="https://main--thinktanked--davidnuescheler.aem.live/tools/snapshot-admin/401.js"></script></head><body><h1>Unauthorized</h1></body>', {
+          return new Response('<html><head><title>Unauthorized</title><script src="https://labs.aem.live/tools/snapshot-admin/401.js"></script></head><body><h1>Unauthorized</h1></body>', {
             status: 401,
             headers: {
               "content-type": "text/html"

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,14 @@
     if (resp.status === 200) {
       const json = await resp.json();
       pages.push(...json.resources.map((e) => e.path));
+      if (json.metadata && json.metadata.reviewPassword) {
+        return new Response('<html><head><title>Unauthorized</title><script src="https://main--thinktanked--davidnuescheler.aem.live/tools/snapshot-admin/401.js"></script></head><body><h1>Unauthorized</h1></body>', {
+          status: 401,
+          headers: {
+            "content-type": "text/html"
+          }
+        });
+      }
     }
 
     const createRobots = async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -79,15 +79,6 @@ import { parse } from 'cookie';
       pages.push(...json.resources.map((e) => e.path));
       if (json.metadata && json.metadata.reviewPassword) {
         const cookies = parse(request.headers.get('cookie') || '');
-        if (!cookies.reviewPassword) {
-          return new Response('<html><head><title>Unauthorized</title><script src="https://main--thinktanked--davidnuescheler.aem.live/tools/snapshot-admin/401.js"></script></head><body><h1>Unauthorized</h1></body>', {
-            status: 401,
-            headers: {
-              "content-type": "text/html"
-            }
-          });
-        }
-
         const sha256 = async (message) => {
           const encoder = new TextEncoder();
           const data = encoder.encode(message);


### PR DESCRIPTION
adding support for a shared secret as a review password that is reuiqred to be entered when the 

`reviewPassword` property is set in `metadata` on the corresponding snapshot