### PR TITLE
Support partial content (mp4s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# wrangler local files
+.wrangler

--- a/src/index.js
+++ b/src/index.js
@@ -210,6 +210,8 @@ async function handleRequest(request, env) {
     const manifestUrl = `https://${reviewInfo.ref}--${reviewInfo.repo}--${reviewInfo.owner}.${AEM_DOMAIN}.page/.snapshots/${reviewInfo.reviewId}/.manifest.json`;
     const manifestRequest = new Request(incomingRequest);
     manifestRequest.headers.set('accept-encoding', 'identity');
+    // since we re-use incoming request headers, we don't want to end up fetching partial manifests
+    manifestRequest.headers.delete('range');
     if (env[`${reviewInfo.owner}-org-token`]) {
         manifestRequest.headers.set('authorization', `token ${env[`${reviewInfo.owner}-org-token`]}`);
     }


### PR DESCRIPTION
## Description
Remove the range header when fetching manifests to avoid trying to fetch a 'partial manifest'... which would lead to non satisfiable range errors (416)

## Related Issue
https://github.com/adobe/helix-reviews/issues/10

## How Has This Been Tested?
Only locally using the wrangler CLI, don't have a CF account.

## Screenshots (if appropriate):
MP4s now properly loading:
<img width="1629" height="718" alt="image" src="https://github.com/user-attachments/assets/5185ce78-58a8-4d05-9307-3464e72f9261" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

