### PR TITLE
Protected content: allow passing an auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# helix-reviews
+## Description
+Install the [wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) and run `wrangler dev` to start a local instance.
+
+## CI/CD & Testing Changes
+Push to a branch to get this deployed on a CI branch for testing; push to main to get this deployed to production.
+
+On the CI branch, you can add a query parameter such as `?hostname=snapshot--main--project--organization` to pull in a specific snapshot for testing purposes.

--- a/src/index.js
+++ b/src/index.js
@@ -165,9 +165,8 @@ const rewriteMetaTags = async (response, url, reviewInfo, incomingRequest) => {
  * @returns {Promise<boolean>} Whether the request is authenticated
  */
 const checkAuthentication = async (metadata, request, reviewInfo, env) => {
-    const authHeader = request.headers.get('authorization');
     if (!metadata?.reviewPassword) return true;
-    if (authHeader && authHeader === `token ${env[`${reviewInfo.owner}-org-token`]}`) return true;
+    if (request.headers.get('authorization') === `token ${env[`${reviewInfo.owner}-org-token`]}`) return true;
 
     const cookies = parse(request.headers.get('cookie') || '');
     const sha256 = async (message) => {


### PR DESCRIPTION
## Description
Fixes https://github.com/adobe/helix-reviews/issues/12 and re-uses any auth header present on the initial request.

## Motivation and Context

Allow to pass an auth header directly to by-pass any review password. Specifically useful for mapping your own CDN/Domains to `aem.reviews` and just proxying the requests.

## How Has This Been Tested?

Locally + on the CI branch.
Tested with: https://helix-reviews-ci.adobeaem.workers.dev/drafts/osahin/college/lcp-fragment-test?hostname=okans-milo-snapshot--main--milo--adobecom
1. Access the snapshot on incognito - 401
2. Access the snapshot with PW (123) - 200
3. GET with wrong auth header  (`authorization: token hlx_fake_...`) - 401
4. GET with right auth header (`authorization: token hlx_...`) - 200

_Info: Scripts, styles, etc. won't load as it's falling back to the default host after the initial request that can be disregarded._

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

