### PR TITLE
fix: add proper permissions and use automatic GITHUB_TOKEN for semantic-release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   semantic_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v4
@@ -18,7 +22,7 @@ jobs:
     - name: Semantic Release
       run: npm run semantic-release
       env:
-        GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CORALOGIX_TAGGER_API_KEY: ${{ secrets.CORALOGIX_TAGGER_API_KEY }}
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         # Deployment variables


### PR DESCRIPTION
## Summary
- Fixed the failing semantic-release workflow by using GitHub's automatic GITHUB_TOKEN
- Added proper permissions for the workflow to create releases and tags

## Changes
- Replaced `${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}` with `${{ secrets.GITHUB_TOKEN }}`
- Added write permissions for contents, issues, and pull-requests

## Why
The semantic-release workflow was failing with `ENOGHTOKEN` error because the `ADOBE_BOT_GITHUB_TOKEN` secret was not available. Using GitHub's automatic token with proper permissions resolves this issue.